### PR TITLE
Remove redundant paragonie/sodium_compat dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "psr/event-dispatcher": "^1.0",
     "doctrine/dbal": "^4.0",
     "firebase/php-jwt": "^6.10",
-    "paragonie/sodium_compat": "^2.0",
     "ext-openssl": "*",
     "ext-simplexml": "*",
     "monolog/monolog": "^3.8",


### PR DESCRIPTION
This package depends on `paragonie/sodium_compat: ^2.0`, but also `php: >=8.2`. Since `libsodium` was added in PHP 7.2, the dependency on `paragonie/sodium_compat` seems redundant?